### PR TITLE
:bug: Test was failling due to sampling.

### DIFF
--- a/test/exact.jl
+++ b/test/exact.jl
@@ -72,8 +72,8 @@ Random.seed!(100)
 
             # compute OT plan
             γ = ot_plan(sqeuclidean, μ, ν)
-            x = randn()
-            @test γ(x) ≈ quantile(ν, cdf(μ, x))
+            x = rand(μ,10)
+            γ.(x) ≈ quantile(ν, cdf(μ,x))
 
             # compute OT cost
             c = ot_cost(sqeuclidean, μ, ν)


### PR DESCRIPTION
The current test returns an error in the "1D continuous case". The problem is that the sample used to evaluate the transport plan is taken from a Normal(0,1) while the acutal mu and nu distributions are something like Normal(-0.6,1), so when calculating the `cdf(\mu, x)`, it actually returns `Inf`, and thus becoming incomparable to `\gamma`.

I fixed to sample from `mu` instead, to avoid such distant value. Also, I did multiple sampling to provide a more robust test.