### PR TITLE
Optimal Transport from 1D Vector

### DIFF
--- a/src/exact.jl
+++ b/src/exact.jl
@@ -118,7 +118,7 @@ A pre-computed optimal transport `plan` may be provided.
 """
 function emd2(μ, ν, C, optimizer; plan=nothing)
     γ = if plan === nothing
-    # compute optimal transport plan
+        # compute optimal transport plan
         emd(μ, ν, C, optimizer)
     else
         # check dimensions
@@ -282,7 +282,7 @@ function ot_plan(_, μ::DiscreteNonParametric, ν::DiscreteNonParametric)
     @inbounds for (idx, (i, j, w)) in enumerate(iter)
         I[idx] = i
         J[idx] = j
-W[idx] = w
+        W[idx] = w
     end
     γ = sparse(I, J, W, length(μprobs), length(νprobs))
 
@@ -307,7 +307,6 @@ See also: [`ot_plan`](@ref), [`emd2`](@ref)
 function ot_cost(c, μ::DiscreteNonParametric, ν::DiscreteNonParametric; plan=nothing)
     return _ot_cost(c, μ, ν, plan)
 end
-
 
 """
     ot_cost(
@@ -338,8 +337,8 @@ function ot_cost(
     ;
     uprobs::AbstractVector{<:Real}=fill(inv(length(usupport)), length(usupport)),
     vprobs::AbstractVector{<:Real}=fill(inv(length(vsupport)), length(vsupport)),
-    plan=nothing
-    )
+    plan=nothing,
+)
     μ = discretemeasure(usupport, uprobs)
     ν = discretemeasure(vsupport, vprobs)
     if plan === nothing
@@ -374,11 +373,10 @@ See also: [`ot_plan`](@ref), [`emd2`](@ref)
 function ot_plan(
     c,
     usupport::AbstractVector{<:Real},
-    vsupport::AbstractVector{<:Real}
-    ;
+    vsupport::AbstractVector{<:Real};
     uprobs::AbstractVector{<:Real}=fill(inv(length(usupport)), length(usupport)),
-    vprobs::AbstractVector{<:Real}=fill(inv(length(vsupport)), length(vsupport)))
-
+    vprobs::AbstractVector{<:Real}=fill(inv(length(vsupport)), length(vsupport)),
+)
     μ = discretemeasure(usupport, uprobs)
     ν = discretemeasure(vsupport, vprobs)
     γ = ot_plan(c, μ, ν)
@@ -415,7 +413,7 @@ function _ot_cost(
     νsupport = support(ν)
     cost = sum(w * c(μsupport[i], νsupport[j]) for (i, j, w) in zip(I, J, W))
 
-return cost
+    return cost
 end
 
 # fallback: compute cost matrix (probably often faster to compute cost from scratch)

--- a/test/exact.jl
+++ b/test/exact.jl
@@ -75,7 +75,7 @@ Random.seed!(100)
             for x in randn(10)
                 @test γ(x) ≈ invlogcdf(ν, logcdf(μ, x))
             end
-
+            
             # compute OT cost
             c = ot_cost(sqeuclidean, μ, ν)
             @test c ≈ (mean(μ) - mean(ν))^2 + (std(μ) - std(ν))^2
@@ -134,7 +134,7 @@ Random.seed!(100)
             @test sum(W) ≈ 1
             @test sort(unique(I)) == 1:m
             @test sort(unique(J)) == 1:n
-            # @test sort(I .+ J) == 2:(m + n)
+            @test sort(I .+ J) == 2:(m + n)
 
             # compute OT cost
             c = @inferred(ot_cost(euclidean, μ, ν))
@@ -180,7 +180,7 @@ Random.seed!(100)
             @test vec(sum(γ; dims=1)) ≈ vprobs
 
             # consistency checks
-            I, J, W = findnz(γ)
+            I, J, W = findnz(γ[sortperm(usupport), sortperm(vsupport)])
             @test all(w > zero(w) for w in W)
             @test sum(W) ≈ 1
             @test sort(unique(I)) == 1:m

--- a/test/exact.jl
+++ b/test/exact.jl
@@ -204,13 +204,13 @@ Random.seed!(100)
             c2 = emd2(fill(1 / m, m), fill(1 / n, n), C, Tulip.Optimizer())
             @test c2 ≈ c rtol = 1e-5
 
-            γ = @inferred(ot_cost(euclidean, usupport, vsupport))
+            γ = @inferred(ot_plan(euclidean, usupport, vsupport))
             # used
-            c2 = @inferred(ot_cost(euclidean, usupport, vsupport, uprobs=reverse(uprobs), vprobs=reverse(vprobs); plan=γ))
+            c2 = @inferred(ot_cost(euclidean, usupport, vsupport; plan=γ))
             @test c2 ≈ c
         end
 
-    end
+            end
 
     @testset "Multivariate Gaussians" begin
         @testset "translation with constant covariance" begin

--- a/test/exact.jl
+++ b/test/exact.jl
@@ -1,7 +1,7 @@
 using ExactOptimalTransport
 
 using Distances
-using PythonOT:PythonOT
+using PythonOT: PythonOT
 using Tulip
 using MathOptInterface
 using Distributions
@@ -75,7 +75,7 @@ Random.seed!(100)
             for x in randn(10)
                 @test γ(x) ≈ invlogcdf(ν, logcdf(μ, x))
             end
-            
+
             # compute OT cost
             c = ot_cost(sqeuclidean, μ, ν)
             @test c ≈ (mean(μ) - mean(ν))^2 + (std(μ) - std(ν))^2
@@ -114,7 +114,7 @@ Random.seed!(100)
             m = 30
             μprobs = normalize!(rand(m), 1)
             μsupport = randn(m)
-        μ = DiscreteNonParametric(μsupport, μprobs)
+            μ = DiscreteNonParametric(μsupport, μprobs)
 
             n = 50
             νprobs = normalize!(rand(n), 1)
@@ -173,7 +173,9 @@ Random.seed!(100)
             vsupport = randn(n)
 
             # compute OT plan
-            γ = @inferred(ot_plan(euclidean, usupport, vsupport, uprobs=uprobs, vprobs=vprobs))
+            γ = @inferred(
+                ot_plan(euclidean, usupport, vsupport; uprobs=uprobs, vprobs=vprobs)
+            )
             @test γ isa SparseMatrixCSC
             @test size(γ) == (m, n)
             @test vec(sum(γ; dims=2)) ≈ uprobs
@@ -188,7 +190,9 @@ Random.seed!(100)
             @test sort(I .+ J) == 2:(m + n)
 
             # compute OT cost
-            c = @inferred(ot_cost(euclidean, usupport, vsupport, uprobs=uprobs, vprobs=vprobs))
+            c = @inferred(
+                ot_cost(euclidean, usupport, vsupport; uprobs=uprobs, vprobs=vprobs)
+            )
 
             # compare with computation with explicit cost matrix
             # DiscreteNonParametric sorts the support automatically, here we have to sort
@@ -209,8 +213,7 @@ Random.seed!(100)
             c2 = @inferred(ot_cost(euclidean, usupport, vsupport; plan=γ))
             @test c2 ≈ c
         end
-
-            end
+    end
 
     @testset "Multivariate Gaussians" begin
         @testset "translation with constant covariance" begin

--- a/test/wasserstein.jl
+++ b/test/wasserstein.jl
@@ -2,6 +2,7 @@ using ExactOptimalTransport
 
 using Distances
 using Distributions
+using LinearAlgebra
 
 using Random
 using Test
@@ -36,7 +37,44 @@ Random.seed!(100)
         end
     end
 
-    @testset "wasserstein" begin
+    @testset "wasserstein 1D discrete" begin
+        m = 10
+        n = 15
+        usupport = randn(m)
+        uprobs   = normalize!(rand(m), 1)
+        vsupport = rand(n)
+        vprobs   = normalize!(rand(n), 1)
+
+        for p in (1, 2, 3, randexp()), metric in (Euclidean(), TotalVariation())
+            for _p in (p, Val(p))
+                # without additional keyword arguments
+                w = wasserstein(usupport, vsupport; p=_p, metric=metric, uprobs=uprobs, vprobs=vprobs)
+                @test w ≈ ot_cost((x, y) -> metric(x, y)^p, usupport, vsupport, uprobs=uprobs, vprobs=vprobs)^(1 / p)
+
+                w = wasserstein(usupport, vsupport; p=_p, metric=metric)
+                @test w ≈ ot_cost((x, y) -> metric(x, y)^p, usupport, vsupport)^(1 / p)
+
+                # without passing the probabilities
+                T = ot_plan((x, y) -> metric(x, y)^p, usupport, vsupport)
+                w2 = wasserstein(usupport, vsupport, p=_p, metric=metric, plan=T)
+                @test w ≈ w2
+            end
+        end
+
+        # check that `Euclidean` is the default `metric`
+        for p in (1, 2, 3, randexp()), _p in (p, Val(p))
+                w = wasserstein(usupport, vsupport; p=_p)
+            @test w ≈ wasserstein(usupport, vsupport; p=_p, metric=Euclidean())
+        end
+
+        # check that `Val(1)` is the default `p`
+        for metric in (Euclidean(), TotalVariation())
+            w = wasserstein(usupport, vsupport; metric=metric)
+            @test w ≈ wasserstein(usupport, vsupport; p=Val(1), metric=metric)
+        end
+    end
+
+    @testset "wasserstein continuous" begin
         μ = Normal(randn(), randexp())
         ν = Normal(randn(), randexp())
         for p in (1, 2, 3, randexp()), metric in (Euclidean(), TotalVariation())

--- a/test/wasserstein.jl
+++ b/test/wasserstein.jl
@@ -41,29 +41,38 @@ Random.seed!(100)
         m = 10
         n = 15
         usupport = randn(m)
-        uprobs   = normalize!(rand(m), 1)
+        uprobs = normalize!(rand(m), 1)
         vsupport = rand(n)
-        vprobs   = normalize!(rand(n), 1)
+        vprobs = normalize!(rand(n), 1)
 
         for p in (1, 2, 3, randexp()), metric in (Euclidean(), TotalVariation())
             for _p in (p, Val(p))
                 # without additional keyword arguments
-                w = wasserstein(usupport, vsupport; p=_p, metric=metric, uprobs=uprobs, vprobs=vprobs)
-                @test w ≈ ot_cost((x, y) -> metric(x, y)^p, usupport, vsupport, uprobs=uprobs, vprobs=vprobs)^(1 / p)
+                w = wasserstein(
+                    usupport, vsupport; p=_p, metric=metric, uprobs=uprobs, vprobs=vprobs
+                )
+                @test w ≈
+                    ot_cost(
+                    (x, y) -> metric(x, y)^p,
+                    usupport,
+                    vsupport;
+                    uprobs=uprobs,
+                    vprobs=vprobs,
+                )^(1 / p)
 
                 w = wasserstein(usupport, vsupport; p=_p, metric=metric)
                 @test w ≈ ot_cost((x, y) -> metric(x, y)^p, usupport, vsupport)^(1 / p)
 
                 # without passing the probabilities
                 T = ot_plan((x, y) -> metric(x, y)^p, usupport, vsupport)
-                w2 = wasserstein(usupport, vsupport, p=_p, metric=metric, plan=T)
+                w2 = wasserstein(usupport, vsupport; p=_p, metric=metric, plan=T)
                 @test w ≈ w2
             end
         end
 
         # check that `Euclidean` is the default `metric`
         for p in (1, 2, 3, randexp()), _p in (p, Val(p))
-                w = wasserstein(usupport, vsupport; p=_p)
+            w = wasserstein(usupport, vsupport; p=_p)
             @test w ≈ wasserstein(usupport, vsupport; p=_p, metric=Euclidean())
         end
 


### PR DESCRIPTION
This PR creates a version of `ot_cost` and `ot_plan` that receives `usupport`, `vsupport` and `uprobs`, `uprobs`. In case the vector of probabilities is not passed, it assumes that all entries have equal probability.

The PR has one test that is failing that I was not able to figure out where is coming from.

One thing that I tried doing was "NOT" sorting the vector, but returning the transport plan for the order given. I'm guessing this is the thing that is causing some issues, because when the transport plan is provided to the `ot_cost` function, it has to reorder it for to be properly used, and I'm guessing there might be some compilation issues. 

