### PR TITLE
Add support for MOI 0.10 and drop Julia < 1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExactOptimalTransport"
 uuid = "24df6009-d856-477c-ac5c-91f668376b31"
 authors = ["JuliaOptimalTransport"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
@@ -18,11 +18,11 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Distances = "0.9.0, 0.10"
 Distributions = "0.24, 0.25"
 FillArrays = "0.12"
-MathOptInterface = "0.9"
+MathOptInterface = "0.9, 0.10"
 PDMats = "0.10, 0.11"
 QuadGK = "2"
 StatsBase = "0.33.8"
-julia = "1"
+julia = "1.6"
 
 [extras]
 HCubature = "19dc6840-f33b-545b-b366-655c7e3ffd49"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExactOptimalTransport"
 uuid = "24df6009-d856-477c-ac5c-91f668376b31"
 authors = ["JuliaOptimalTransport"]
-version = "0.1.3"
+version = "0.2.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ ExactOptimalTransport = "24df6009-d856-477c-ac5c-91f668376b31"
 
 [compat]
 Documenter = "0.27"
-ExactOptimalTransport = "0.1"
+ExactOptimalTransport = "0.2"


### PR DESCRIPTION
This PR adds support for MOI 0.10. It can't be tested on Julia 1.0 (see https://github.com/JuliaOptimalTransport/ExactOptimalTransport.jl/pull/7) and hence I dropped support for older Julia versions < 1.6. This seems safe to do now that Julia 1.6 is the LTS. It is also in line with other major parts of the Julia ecosystem such as SciML: https://sciml.ai/news/2021/12/02/lts/index.html