### PR TITLE
Add DOI with Zenodo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExactOptimalTransport"
 uuid = "24df6009-d856-477c-ac5c-91f668376b31"
 authors = ["JuliaOptimalTransport"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaOptimalTransport.github.io/ExactOptimalTransport.jl/stable)
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaOptimalTransport.github.io/ExactOptimalTransport.jl/dev)
 [![CI](https://github.com/JuliaOptimalTransport/ExactOptimalTransport.jl/workflows/CI/badge.svg?branch=main)](https://github.com/JuliaOptimalTransport/ExactOptimalTransport.jl/actions?query=workflow%3ACI+branch%3Amain)
+[![DOI](https://zenodo.org/badge/402808845.svg)](https://zenodo.org/badge/latestdoi/402808845)
 [![Codecov](https://codecov.io/gh/JuliaOptimalTransport/ExactOptimalTransport.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaOptimalTransport/ExactOptimalTransport.jl)
 [![Coveralls](https://coveralls.io/repos/github/JuliaOptimalTransport/ExactOptimalTransport.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaOptimalTransport/ExactOptimalTransport.jl?branch=main)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)


### PR DESCRIPTION
Based on #34, I enabled Zenodo also for ExactOptimalTransport. This PR adds a badge (based on https://gist.github.com/seignovert/ae6771f400ca464d294261f42900823a) that should display the DOI and link to Zenodo once a new release is tagged.